### PR TITLE
Code de conduite

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Faire un évènement plus technique pour accueillir les nouveaux venus dans la c
 - Fin vers 22h
 
 ## Prérequis de participation:
+- Avoir lu notre [code de conduite](https://github.com/ParisRubyWorkshop/meetup/blob/master/code_de_conduite.md) et le suivre
 - Apporter un laptop avec ruby et git installés (et rbenv ou rvm si possible)
 - Savoir au moins faire un hello world sur ruby (pas difficile ;) )
 

--- a/code_de_conduite.md
+++ b/code_de_conduite.md
@@ -2,6 +2,8 @@
 
 Le but premier du Paris Ruby Workshop est d'accueillir *tous* les nouveaux venus dans la communauté ruby parisienne, indépendemment de leur genre, leur origine, leur orientation sexuelle, leur apparence physique, leur handicap ou leur religion.
 
+Nous voulons faire du meetup un cadre agréable et
+
 Tous les participants et sponsors pour notre conférence doivent accepter ce code de conduite.
 
 Les organisateurs s'attacheront à faire respecter ce code pendant le meetup.

--- a/code_de_conduite.md
+++ b/code_de_conduite.md
@@ -12,7 +12,7 @@ Notre workshop se veut une expérience sans harcèlement, quelque soit votre gen
 
 Le harcèlement inclut des commentaires sur le sexe, l'orientation sexuelle, le handicap, l'apparence physique, le poids, la race, ou la religion, ainsi que les images à connotation sexuelle dans des lieux publics, les intimidations délibérées, la traque, la poursuite, un harcèlement photographique ou vidéo, un contact physique inapproprié et des avances sexuelles non désirées.
 
-Les participant.e.s à qui il sera demandé d'arrêter tout comportement de harcèlement doivent arrêter immédiatement.
+Les participant.e.s à qui il sera demandé d'arrêter tout comportement de harcèlement devront arrêter immédiatement.
 
 Les sponsors sont aussi sujet à la politique anti-harcèlement. En particulier, les sponsors ne doivent pas utiliser d'images ou de matériels à connotation sexuelle. Ils ne doivent pas non plus engager d'activités à connotation sexuelle.
 Ils ne doivent pas non plus créer un environnement sexualisé.

--- a/code_de_conduite.md
+++ b/code_de_conduite.md
@@ -8,7 +8,7 @@ Tou.te.s les participant.e.s et sponsors du workshop doivent accepter ce code de
 
 Les organisateurs s'attacheront à faire respecter ce code pendant le workshop.
 
-Notre workshop se veut une expérience sans harcèlement, quelque soit votre genre, orientation sexuelle, handicap, votre apparence physique, votre poids ou votre religion. Nous ne tolérons aucun harcèlement des participant.e.s au workshop, quelque soit sa forme. Les expressions et les images à connotation sexuelle ne sont pas appropriées lors de l'événement. Les participant.e.s au workshop qui ne respectent pas ces règles peuvent être exclus du workshop, à la discrétion des organisateurs du workshop.
+Notre workshop se veut une expérience sans harcèlement, quelque soit votre genre, orientation sexuelle, handicap, votre apparence physique, votre poids ou votre religion. Nous ne tolérons aucun harcèlement des participant.e.s au workshop, quelque soit sa forme. Les participant.e.s au workshop qui ne respectent pas ces règles peuvent être exclus du workshop, à la discrétion des organisateurs du workshop.
 
 Le harcèlement inclut des commentaires sur le sexe, l'orientation sexuelle, le handicap, l'apparence physique, le poids, la race, ou la religion, ainsi que les images à connotation sexuelle dans des lieux publics, les intimidations délibérées, la traque, la poursuite, un harcèlement photographique ou vidéo, un contact physique inapproprié et des avances sexuelles non désirées.
 

--- a/code_de_conduite.md
+++ b/code_de_conduite.md
@@ -1,0 +1,32 @@
+# Code de conduite du Paris Ruby Workshop
+
+Le but premier du Paris Ruby Workshop est d'accueillir *tous* les nouveaux venus dans la communauté ruby parisienne, indépendemment de leur genre, leur origine, leur orientation sexuelle, leur apparence physique, leur handicap ou leur religion.
+
+Tous les participants et sponsors pour notre conférence doivent accepter ce code de conduite.
+
+Les organisateurs s'attacheront à faire respecter ce code pendant le meetup.
+
+Nous attendons de la part de chaque participant une coopération pour assurer un environnement sain et agréable pour tous.
+
+En bref, soyez quelqu'un de bien. :)
+Besoin d'aide ?
+
+# La version rapide
+
+Notre meetup se veut une expérience sans harcèlement, quelque soit votre genre, orientation sexuelle, handicap, votre apparence physique, votre poids ou votre religion. Nous ne tolérons aucun harcèlement des participants au meetup, quelque soit sa forme. Les expressions et les images à connotation sexuelle ne sont pas appropriées lors de l'événement. Les participants à la conférence qui ne respectent pas ces règles peuvent être exclus du meetup, à la discrétion des organisateurs de la conférence.
+
+# La version moins rapide
+
+Le harcèlement inclut des commentaires oraux sur le sexe, l'orientation sexuelle, le handicap, l'apparence physique, le poids, la race, la religion, les images à connotation sexuelle dans des lieux publics, les intimidations délibérées, la traque, la poursuite, un harcèlement photographique ou vidéo, une suite d'interruption des conférences et des autres événements, un contact physique inapproprié et des avances sexuelles non désirées.
+
+Les participants à qui il sera demandé d'arrêter tout comportement de harcèlement doivent arrêter immédiatement.
+
+Les sponsors sont aussi sujet à la politique anti-harcèlement. En particulier, les sponsors ne doivent pas utiliser d'images ou de matériels à connotation sexuelle. Ils ne doivent pas non plus engager d'activités à connotation sexuelle. L'équipe du stand (y compris les volontaires) ne doivent pas utiliser de vêtements, uniformes ou costumes à connotation sexuelle. Ils ne doivent pas non plus créer un environnement sexualisé.
+
+Si un participant a un comportement de harcèlement, les organisateurs de la conférence peuvent prendre toute action qui leur semble adéquate. Cela va d'un simple avertissement à l'exclusion du participant de la conférence sans remboursement.
+
+Si vous vous sentez harcelé, si vous pensez que quelqu'un se fait harceler, et plus généralement en cas de problème, merci de contacter immédiatement un membre de l'organisation de l'événement. Les membres sont facilement identifiables à leur t-shirts aux couleurs de l'événement.
+
+Les membres de l'organisation seront ravis d'aider les participants à contacter la sécurité de l'hôtel ou du bâtiment où se déroule l'événement, ou les forces de l'ordre, à fournir une escorte ainsi qu'à aider de toute autre façon les personnes victimes de harcèlement, pour garantir leur sécurité pendant la durée de l'événement. Nous apprécions votre participation à l'événement.
+
+Nous attendons des participants qu'ils suivent ces règles dans le bâtiment des conférences et des ateliers, ainsi que pendant les événements sociaux relatifs à la conférence.

--- a/code_de_conduite.md
+++ b/code_de_conduite.md
@@ -1,34 +1,26 @@
 # Code de conduite du Paris Ruby Workshop
 
-Le but premier du Paris Ruby Workshop est d'accueillir *tous* les nouveaux venus dans la communauté ruby parisienne, indépendemment de leur genre, leur origine, leur orientation sexuelle, leur apparence physique, leur handicap ou leur religion.
+Le but premier du Paris Ruby Workshop est d'accueillir *tou.te.s* les nouveaux.elles venu.e.s dans la communauté ruby parisienne, et de permettre à tou.te.s d'échanger sur des sujets techniques et humains autour du Ruby et du logiciel en général.
 
-Nous voulons faire du meetup un cadre agréable et
+Nous voulons donc faire du workshop un cadre agréable où chacun.e se sent en sécurité. En participant au workshop vous rencontrerez des gens différents de vous: soyez respecteux.ses de leur identité aussi bien que de leur manière de coder. Nous attendons de vous une coopération pour assurer un environnement sain et agréable pour tou.te.s.
 
-Tous les participants et sponsors pour notre conférence doivent accepter ce code de conduite.
+Tou.te.s les participant.e.s et sponsors du workshop doivent accepter ce code de conduite.
 
-Les organisateurs s'attacheront à faire respecter ce code pendant le meetup.
+Les organisateurs s'attacheront à faire respecter ce code pendant le workshop.
 
-Nous attendons de la part de chaque participant une coopération pour assurer un environnement sain et agréable pour tous.
+Notre workshop se veut une expérience sans harcèlement, quelque soit votre genre, orientation sexuelle, handicap, votre apparence physique, votre poids ou votre religion. Nous ne tolérons aucun harcèlement des participant.e.s au workshop, quelque soit sa forme. Les expressions et les images à connotation sexuelle ne sont pas appropriées lors de l'événement. Les participant.e.s au workshop qui ne respectent pas ces règles peuvent être exclus du workshop, à la discrétion des organisateurs du workshop.
 
-En bref, soyez quelqu'un de bien. :)
-Besoin d'aide ?
+Le harcèlement inclut des commentaires sur le sexe, l'orientation sexuelle, le handicap, l'apparence physique, le poids, la race, ou la religion, ainsi que les images à connotation sexuelle dans des lieux publics, les intimidations délibérées, la traque, la poursuite, un harcèlement photographique ou vidéo, un contact physique inapproprié et des avances sexuelles non désirées.
 
-# La version rapide
+Les participant.e.s à qui il sera demandé d'arrêter tout comportement de harcèlement doivent arrêter immédiatement.
 
-Notre meetup se veut une expérience sans harcèlement, quelque soit votre genre, orientation sexuelle, handicap, votre apparence physique, votre poids ou votre religion. Nous ne tolérons aucun harcèlement des participants au meetup, quelque soit sa forme. Les expressions et les images à connotation sexuelle ne sont pas appropriées lors de l'événement. Les participants à la conférence qui ne respectent pas ces règles peuvent être exclus du meetup, à la discrétion des organisateurs de la conférence.
+Les sponsors sont aussi sujet à la politique anti-harcèlement. En particulier, les sponsors ne doivent pas utiliser d'images ou de matériels à connotation sexuelle. Ils ne doivent pas non plus engager d'activités à connotation sexuelle.
+Ils ne doivent pas non plus créer un environnement sexualisé.
 
-# La version moins rapide
+Si un participant a un comportement de harcèlement, les organisateurs du workshop peuvent prendre toute action qui leur semble adéquate. Cela va d'un simple avertissement à l'exclusion du participant du workshop.
 
-Le harcèlement inclut des commentaires oraux sur le sexe, l'orientation sexuelle, le handicap, l'apparence physique, le poids, la race, la religion, les images à connotation sexuelle dans des lieux publics, les intimidations délibérées, la traque, la poursuite, un harcèlement photographique ou vidéo, une suite d'interruption des conférences et des autres événements, un contact physique inapproprié et des avances sexuelles non désirées.
+Si vous vous sentez harcelé, si vous pensez que quelqu'un se fait harceler, et plus généralement en cas de problème, merci de contacter immédiatement un membre de l'organisation du workshop
 
-Les participants à qui il sera demandé d'arrêter tout comportement de harcèlement doivent arrêter immédiatement.
 
-Les sponsors sont aussi sujet à la politique anti-harcèlement. En particulier, les sponsors ne doivent pas utiliser d'images ou de matériels à connotation sexuelle. Ils ne doivent pas non plus engager d'activités à connotation sexuelle. L'équipe du stand (y compris les volontaires) ne doivent pas utiliser de vêtements, uniformes ou costumes à connotation sexuelle. Ils ne doivent pas non plus créer un environnement sexualisé.
 
-Si un participant a un comportement de harcèlement, les organisateurs de la conférence peuvent prendre toute action qui leur semble adéquate. Cela va d'un simple avertissement à l'exclusion du participant de la conférence sans remboursement.
-
-Si vous vous sentez harcelé, si vous pensez que quelqu'un se fait harceler, et plus généralement en cas de problème, merci de contacter immédiatement un membre de l'organisation de l'événement. Les membres sont facilement identifiables à leur t-shirts aux couleurs de l'événement.
-
-Les membres de l'organisation seront ravis d'aider les participants à contacter la sécurité de l'hôtel ou du bâtiment où se déroule l'événement, ou les forces de l'ordre, à fournir une escorte ainsi qu'à aider de toute autre façon les personnes victimes de harcèlement, pour garantir leur sécurité pendant la durée de l'événement. Nous apprécions votre participation à l'événement.
-
-Nous attendons des participants qu'ils suivent ces règles dans le bâtiment des conférences et des ateliers, ainsi que pendant les événements sociaux relatifs à la conférence.
+Ce code de conduite est inspiré du Code of Conduct de la [JS conf 2012](http://2012.jsconf.us/#/about). Si vous pensez qu'il peut être amélioré, nous serons ravi.e.s d'en discuter à l'oral, sur slack ou via une pull request.


### PR DESCRIPTION
Ce code de conduite affirme nos valeurs, et notre volonté d'être une porte d'entrée de la communauté Ruby ouverte à tous et toutes.

Je suis parti du template assez standard de [codeofconduct.com](http://fr.confcodeofconduct.com/), que j'ai ajusté pour le contexte du workshop et pour utiliser un langage non-sexiste.

Il est très possible que j'ai oublié quelque chose, ou qu'il y ai des maladresses dans cette version. Merci de donner votre feedback. :-)

Pour plus de lecture, je vous recommande [ce très bon article](https://www.ashedryden.com/blog/codes-of-conduct-101-faq) qui explique pourquoi tout évènement technique devrait avoir un code de conduite, ainsi que [ce guide pratique](http://www.haut-conseil-egalite.gouv.fr/IMG/pdf/hcefh__guide_pratique_com_sans_stereo-_vf-_2015_11_05.pdf) de communication non sexiste.

Il n'y a pas que dans le code que le langage est important. ;-)